### PR TITLE
fix(cspell): diagnostic builtin finds local config

### DIFF
--- a/lua/null-ls/builtins/diagnostics/cspell.lua
+++ b/lua/null-ls/builtins/diagnostics/cspell.lua
@@ -36,7 +36,7 @@ return h.make_builtin({
                 "lint",
                 "--language-id",
                 params.ft,
-                "stdin",
+                params.bufname,
             }
 
             -- only enable suggestions when using the code actions built-in, since they slow down the command


### PR DESCRIPTION
The cspell diagnostic builtin is unable to find local configuration files because the cli is being provided stdin, which isn't aware of the file's path. The global configuration file is used instead.

The code_action builtin works correctly - when you choose the "add to cspell json" action, it adds it the local config. However since the diagnostic builtin is using the global config, the error does not go away.

This resolves the issue. I didn't see a contributing doc, but let me know if you need anything else from my end. I can provide a minimal repro sample or some more detailed steps if necessary.